### PR TITLE
[SUS-60] 모의고사 수정 & 삭제 & 랭킹

### DIFF
--- a/src/core/controller/module/checkAuthReturningUserId.ts
+++ b/src/core/controller/module/checkAuthReturningUserId.ts
@@ -9,27 +9,27 @@ const checkAuthReturningUserId = (
   if (auth === 'login') {
     const token = req.cookies.loginToken
     if (!token) {
-      throw ErrorRegistry.TOKEN_REQUIRED
+      throw ErrorRegistry.LOGIN_REQUIRED
     }
     if (!process.env.JWT_SIGNATURE_KEY) {
       throw ErrorRegistry.INTERNAL_SERVER_ERROR
     }
     const data: any = jwt.verify(token, process.env.JWT_SIGNATURE_KEY)
     if (!data.idx) {
-      throw ErrorRegistry.TOKEN_REQUIRED
+      throw ErrorRegistry.LOGIN_REQUIRED
     }
     return data.idx
   } else if (auth === 'admin') {
     const token = req.cookies.loginToken
     if (!token) {
-      throw ErrorRegistry.TOKEN_REQUIRED
+      throw ErrorRegistry.LOGIN_REQUIRED
     }
     if (!process.env.JWT_SIGNATURE_KEY) {
       throw ErrorRegistry.INTERNAL_SERVER_ERROR
     }
     const data: any = jwt.verify(token, process.env.JWT_SIGNATURE_KEY)
     if (!data.idx) {
-      throw ErrorRegistry.TOKEN_REQUIRED
+      throw ErrorRegistry.LOGIN_REQUIRED
     }
     if (data.role !== 'admin') {
       throw ErrorRegistry.ACCESS_DENIED

--- a/src/core/error/ErrorRegistry.ts
+++ b/src/core/error/ErrorRegistry.ts
@@ -66,6 +66,16 @@ export default class ErrorRegistry {
     'MO001',
     '모의고사가 존재하지 않습니다',
   )
+  static readonly MOCK_DELETE_FAILED = new CustomError(
+    400,
+    'MO002',
+    '모의고사 삭제에 실패했습니다',
+  )
+  static readonly MOCK_EDIT_FAILED = new CustomError(
+    400,
+    'MO002',
+    '모의고사 수정에 실패했습니다',
+  )
 
   // Notice(NO)
   static readonly CAN_NOT_FINE_NOTICE = new CustomError(

--- a/src/core/error/ErrorRegistry.ts
+++ b/src/core/error/ErrorRegistry.ts
@@ -66,15 +66,15 @@ export default class ErrorRegistry {
     'MO001',
     '모의고사가 존재하지 않습니다',
   )
-  static readonly MOCK_DELETE_FAILED = new CustomError(
-    400,
-    'MO002',
-    '모의고사 삭제에 실패했습니다',
-  )
   static readonly MOCK_EDIT_FAILED = new CustomError(
     400,
     'MO002',
     '모의고사 수정에 실패했습니다',
+  )
+  static readonly MOCK_DELETE_FAILED = new CustomError(
+    400,
+    'MO003',
+    '모의고사 삭제에 실패했습니다',
   )
 
   // Notice(NO)

--- a/src/core/util/multipartParser/index.ts
+++ b/src/core/util/multipartParser/index.ts
@@ -12,7 +12,11 @@ const replaceBaseUrl = (url: string): string => {
 }
 
 const multipartParser = (contentType: string, limit: number) => {
-  return (req: Request, res: Response, next: NextFunction) => {
+  return (
+    req: Request<any, any, any, any>,
+    res: Response,
+    next: NextFunction,
+  ) => {
     multer.array(contentType, limit)(req, res, (err) => {
       if (err) {
         console.error(err)

--- a/src/core/util/multipartParser/index.ts
+++ b/src/core/util/multipartParser/index.ts
@@ -10,6 +10,7 @@ const newBaseUrl = process.env.AWS_CLOUDFRONT_BASE_URL as string
 const replaceBaseUrl = (url: string): string => {
   return newBaseUrl + url.slice(oldBaseUrl.length)
 }
+
 const multipartParser = (contentType: string, limit: number) => {
   return (req: Request, res: Response, next: NextFunction) => {
     multer.array(contentType, limit)(req, res, (err) => {

--- a/src/mock/entity/dao/db/MockResultFromDB.ts
+++ b/src/mock/entity/dao/db/MockResultFromDB.ts
@@ -10,4 +10,9 @@ export default interface MockResultFromDB {
   writerNickname: string
   images: string[]
   firstQuizIdx: UUID
+  ranks: {
+    rank: number
+    nickName: string
+    score: number
+  }[]
 }

--- a/src/mock/entity/dao/frontend/request/body/MockEditRequest.ts
+++ b/src/mock/entity/dao/frontend/request/body/MockEditRequest.ts
@@ -1,17 +1,17 @@
 interface MockEditRequestParams {
   title: string
   description: string
-  urls: string[]
+  uploadUrls: string[]
 }
 
 export default class MockEditRequest {
   title: string
   description: string
-  urls: string[]
+  uploadUrls: string[]
 
-  constructor(public params: MockEditRequestParams) {
+  constructor(params: MockEditRequestParams) {
     this.title = params.title
     this.description = params.description
-    this.urls = params.urls
+    this.uploadUrls = params.uploadUrls
   }
 }

--- a/src/mock/entity/dao/frontend/request/body/MockEditRequest.ts
+++ b/src/mock/entity/dao/frontend/request/body/MockEditRequest.ts
@@ -1,0 +1,17 @@
+interface MockEditRequestParams {
+  title: string
+  description: string
+  urls: string[]
+}
+
+export default class MockEditRequest {
+  title: string
+  description: string
+  urls: string[]
+
+  constructor(public params: MockEditRequestParams) {
+    this.title = params.title
+    this.description = params.description
+    this.urls = params.urls
+  }
+}

--- a/src/mock/entity/dao/frontend/response/DetailResponse.ts
+++ b/src/mock/entity/dao/frontend/response/DetailResponse.ts
@@ -8,6 +8,11 @@ export default class DetailResponse {
   writerNickname: string
   images: string[]
   firstQuizIdx: UUID
+  ranks: {
+    rank: number
+    nickName: string
+    score: number
+  }[]
 
   constructor(
     title: string,
@@ -17,6 +22,11 @@ export default class DetailResponse {
     writerNickname: string,
     images: string[],
     firstQuizIdx: UUID,
+    ranks: {
+      rank: number
+      nickName: string
+      score: number
+    }[],
   ) {
     this.title = title
     this.description = description
@@ -25,5 +35,6 @@ export default class DetailResponse {
     this.writerNickname = writerNickname
     this.images = images
     this.firstQuizIdx = firstQuizIdx
+    this.ranks = ranks
   }
 }

--- a/src/mock/repository/MockRepository.ts
+++ b/src/mock/repository/MockRepository.ts
@@ -287,7 +287,8 @@ export default class MockRepository {
           title = $3,
           description = $4,
           updated_at = NOW()
-        WHERE idx = $2 AND member_idx = $1
+        FROM member
+        WHERE mock.idx = $2 AND (mock.member_idx = $1 OR member.role = 'ADMIN')
         RETURNING 1
       )
       UPDATE image SET urls = $5 WHERE article_idx = $2 AND EXISTS (SELECT 1 FROM mock_update)
@@ -298,7 +299,10 @@ export default class MockRepository {
 
   static async deleteMock(memberIdx: number, idx: UUID) {
     return await postgres.query(
-      `UPDATE mock SET is_deleted = true WHERE idx = $2 AND member_idx = $1`,
+      `UPDATE mock 
+      SET is_deleted = true
+      FROM member
+      WHERE mock.idx = $2 AND (mock.member_idx = $1 OR member.role = 'ADMIN')`,
       [memberIdx, idx],
     )
   }

--- a/src/mock/repository/MockRepository.ts
+++ b/src/mock/repository/MockRepository.ts
@@ -288,7 +288,9 @@ export default class MockRepository {
           description = $4,
           updated_at = NOW()
         FROM member
-        WHERE mock.idx = $2 AND (mock.member_idx = $1 OR member.role = 'ADMIN')
+        WHERE mock.idx = $2 
+            AND member.idx = $1
+            AND (mock.member_idx = $1 OR member.role = 'ADMIN')
         RETURNING 1
       )
       UPDATE image SET urls = $5 WHERE article_idx = $2 AND EXISTS (SELECT 1 FROM mock_update)
@@ -302,7 +304,9 @@ export default class MockRepository {
       `UPDATE mock 
       SET is_deleted = true
       FROM member
-      WHERE mock.idx = $2 AND (mock.member_idx = $1 OR member.role = 'ADMIN')`,
+      WHERE mock.idx = $2 
+        AND member.idx = $1
+        AND (mock.member_idx = $1 OR member.role = 'ADMIN')`,
       [memberIdx, idx],
     )
   }

--- a/src/mock/repository/MockScoreRepository.ts
+++ b/src/mock/repository/MockScoreRepository.ts
@@ -122,4 +122,18 @@ export default class MockScoreRepository {
       [mockIdx, memberIdx],
     )
   }
+
+  static async getRank(mockIdx: UUID) {
+    return await postgres.query(
+      `SELECT
+        RANK() OVER (ORDER BY score DESC) AS "rank",
+        member.nickName AS "nickName",
+        score,
+      FROM mock_score 
+      JOIN member ON mock_score.member_idx = member.idx
+      WHERE mock_idx = $1 
+      ORDER BY score DESC`,
+      [mockIdx],
+    )
+  }
 }

--- a/src/mock/router/mockItemRouter.ts
+++ b/src/mock/router/mockItemRouter.ts
@@ -81,7 +81,7 @@ mockItemRouter.delete(
     null,
   )(async (req, res) => {
     await MockItemService.deleteMock(req.memberIdx, req.params)
-    res.sendStatus(204)
+    res.sendStatus(200)
   }),
 )
 
@@ -96,18 +96,6 @@ mockItemRouter.patch(
     null,
   )(async (req, res) => {
     await MockItemService.editMock(req.memberIdx, req.params, req.body)
-    res.sendStatus(204)
-  }),
-)
-mockItemRouter.get(
-  '/:idx/result/rank',
-  controller(
-    'login',
-    null,
-    MockIdxPath,
-    null,
-    null,
-  )(async (req, res) => {
-    return res.send(await MockItemService.getRank(req.memberIdx, req.params))
+    res.sendStatus(200)
   }),
 )

--- a/src/mock/router/mockItemRouter.ts
+++ b/src/mock/router/mockItemRouter.ts
@@ -1,6 +1,8 @@
 import controller from '#controller'
 import express from 'express'
 
+import multipartParser from '#util/multipartParser'
+import MockEditRequest from '../entity/dao/frontend/request/body/MockEditRequest.js'
 import MockIdxPath from '../entity/dao/frontend/request/path/MockIdxPath.js'
 import DetailResponse from '../entity/dao/frontend/response/DetailResponse.js'
 import IndividualMockInfoResponse from '../entity/dao/frontend/response/IndividualDetailResponse.js'
@@ -66,5 +68,46 @@ mockItemRouter.get(
         path: req.params,
       }),
     )
+  }),
+)
+
+mockItemRouter.delete(
+  '/:idx/delete',
+  controller(
+    'login',
+    null,
+    MockIdxPath,
+    null,
+    null,
+  )(async (req, res) => {
+    await MockItemService.deleteMock(req.memberIdx, req.params)
+    res.sendStatus(204)
+  }),
+)
+
+mockItemRouter.patch(
+  '/:idx/edit',
+  multipartParser('image', 1),
+  controller(
+    'login',
+    null,
+    MockIdxPath,
+    MockEditRequest,
+    null,
+  )(async (req, res) => {
+    await MockItemService.editMock(req.memberIdx, req.params, req.body)
+    res.sendStatus(204)
+  }),
+)
+mockItemRouter.get(
+  '/:idx/result/rank',
+  controller(
+    'login',
+    null,
+    MockIdxPath,
+    null,
+    null,
+  )(async (req, res) => {
+    return res.send(await MockItemService.getRank(req.memberIdx, req.params))
   }),
 )

--- a/src/mock/service/MockItemService.ts
+++ b/src/mock/service/MockItemService.ts
@@ -10,6 +10,9 @@ import MockScoreRepository from '../repository/MockScoreRepository.js'
 export default class MockItemService {
   static async getMockDetail(path: MockIdxPath): Promise<DetailResponse> {
     const result = await MockRepository.getMock(path.idx)
+    if (!result) {
+      throw ErrorRegistry.CAN_NOT_FIND_MOCK
+    }
 
     return new DetailResponse(
       result.title,

--- a/src/mock/service/MockItemService.ts
+++ b/src/mock/service/MockItemService.ts
@@ -1,3 +1,4 @@
+import MockEditRequest from '../entity/dao/frontend/request/body/MockEditRequest.js'
 import MockIdxPath from '../entity/dao/frontend/request/path/MockIdxPath.js'
 import DetailResponse from '../entity/dao/frontend/response/DetailResponse.js'
 import IndividualDetailResponse from '../entity/dao/frontend/response/IndividualDetailResponse.js'
@@ -57,5 +58,28 @@ export default class MockItemService {
       result.solved,
       result.pushLike,
     )
+  }
+
+  static async editMock(
+    userIdx: number,
+    path: MockIdxPath,
+    body: MockEditRequest,
+  ): Promise<void> {
+    const result = await MockRepository.updateMock(
+      userIdx,
+      path.idx,
+      body.title,
+      body.description,
+      body.urls,
+    )
+    console.log(result)
+  }
+
+  static async deleteMock(userIdx: number, path: MockIdxPath): Promise<void> {
+    await MockRepository.deleteMock(userIdx, path.idx)
+  }
+
+  static async getRank(userIdx: number, path: MockIdxPath): Promise<void> {
+    const result = await MockScoreRepository.getScore(userIdx, path.idx)
   }
 }

--- a/src/mock/service/MockItemService.ts
+++ b/src/mock/service/MockItemService.ts
@@ -75,14 +75,14 @@ export default class MockItemService {
       body.uploadUrls,
     )
     if (result.rowCount === 0) {
-      throw ErrorRegistry.ACCESS_DENIED
+      throw ErrorRegistry.MOCK_EDIT_FAILED
     }
   }
 
   static async deleteMock(userIdx: number, path: MockIdxPath): Promise<void> {
     const result = await MockRepository.deleteMock(userIdx, path.idx)
     if (result.rowCount === 0) {
-      throw ErrorRegistry.ACCESS_DENIED
+      throw ErrorRegistry.MOCK_DELETE_FAILED
     }
   }
 }

--- a/src/mock/service/MockItemService.ts
+++ b/src/mock/service/MockItemService.ts
@@ -1,3 +1,4 @@
+import ErrorRegistry from '#error/ErrorRegistry'
 import MockEditRequest from '../entity/dao/frontend/request/body/MockEditRequest.js'
 import MockIdxPath from '../entity/dao/frontend/request/path/MockIdxPath.js'
 import DetailResponse from '../entity/dao/frontend/response/DetailResponse.js'
@@ -18,6 +19,7 @@ export default class MockItemService {
       result.writerNickname,
       result.images,
       result.firstQuizIdx,
+      result.ranks,
     )
   }
 
@@ -70,16 +72,17 @@ export default class MockItemService {
       path.idx,
       body.title,
       body.description,
-      body.urls,
+      body.uploadUrls,
     )
-    console.log(result)
+    if (result.rowCount === 0) {
+      throw ErrorRegistry.ACCESS_DENIED
+    }
   }
 
   static async deleteMock(userIdx: number, path: MockIdxPath): Promise<void> {
-    await MockRepository.deleteMock(userIdx, path.idx)
-  }
-
-  static async getRank(userIdx: number, path: MockIdxPath): Promise<void> {
-    const result = await MockScoreRepository.getScore(userIdx, path.idx)
+    const result = await MockRepository.deleteMock(userIdx, path.idx)
+    if (result.rowCount === 0) {
+      throw ErrorRegistry.ACCESS_DENIED
+    }
   }
 }


### PR DESCRIPTION
## 📢 설명
- 모의고사 수정 기능을 구현했습니다
- 모의고사 삭제 기능을 구현했습니다
- 이제 모의고사 상세정보에서 모의고사 랭킹도 점수 내림차순 15등까지 가져옵니다
```
{
    "title": "신창섭 퀴즈",
    "description": "<p><br></p>",
    ...
    "ranks": [
        {
            "rank": 1,
            "nickname": "활기찬 올빼미",
            "score": 535
        },
        {
            "rank": 2,
            "nickname": "에이아이레나",
            "score": 475
        }
    ]
}
```

## ✅ 체크 리스트
- [x] 모의고사 작성한 사람 또는 관리자일 때 모의고사를 수정할 수 있는지 테스트
- [x] 권한이 없는 사람이 모의고사를 수정하면 아래와 같은 오류가 나오는지 확인
```
{
    "status": 400,
    "code": "MO002",
    "message": "모의고사 수정에 실패했습니다"
}
```
- [x] 모의고사 상세보기 조회하여 수정되었는지 확인
- [x] 모의고사 작성한 사람 또는 관리자일 때 모의고사를 삭제할 수 있는지 테스트
- [x] 권한이 없는 사람이 모의고사를 삭제하면 아래와 같은 오류가 나오는지 확인
```
{
    "status": 400,
    "code": "MO003",
    "message": "모의고사 삭제에 실패했습니다"
}
```
- [x] 모의고사 목록 조회 API 요청해보고 해당 모의고사가 조회되지 않는지 확인
- [x] 코드 리뷰
