### PR TITLE
[SUS-68] 공지사항 검색 API 수정

### DIFF
--- a/src/notice/entity/dto/NoticeList.ts
+++ b/src/notice/entity/dto/NoticeList.ts
@@ -4,6 +4,7 @@ export default class NoticeList {
   lastPageNumber: number
   prevPageExist: boolean
   nextPageExist: boolean
+  totalCount: number
   notices: {
     idx: number
     title: string
@@ -23,6 +24,7 @@ export default class NoticeList {
       totalCount: number
     }[],
   ) {
+    this.totalCount = totalCount
     this.currentPageNumber = currentPageNumber
     this.firstPageNumber = Math.floor((currentPageNumber - 1) / 10) * 10 + 1
     const pageOffset = Math.min(

--- a/src/notice/repository/NoticeRepository.ts
+++ b/src/notice/repository/NoticeRepository.ts
@@ -50,8 +50,11 @@ export default class NoticeRepository {
       )
     ).rows
     const totalCountResult = (
-      await postgres.query(`SELECT COUNT(*) AS totalCount FROM notice`)
-    ).rows[0]
+      await postgres.query(
+        `SELECT COUNT(*) AS "totalCount" FROM notice WHERE is_deleted = 'f' AND title LIKE $1`,
+        [titleToSearch],
+      )
+    ).rows[0].totalCount
     return {
       listResult,
       totalCountResult,

--- a/src/notice/repository/NoticeRepository.ts
+++ b/src/notice/repository/NoticeRepository.ts
@@ -22,7 +22,7 @@ export default class NoticeRepository {
     ).rows
     const totalCountResult = (
       await postgres.query(`SELECT COUNT(*) AS "totalCount" FROM notice`)
-    ).rows[0]
+    ).rows[0].totalCount
     return {
       listResult,
       totalCountResult,

--- a/src/notice/repository/NoticeRepository.ts
+++ b/src/notice/repository/NoticeRepository.ts
@@ -29,7 +29,7 @@ export default class NoticeRepository {
     }
   }
   static async getSearchListFromDb(
-    title: string,
+    titleToSearch: string,
     display: number,
     offset: number,
   ) {
@@ -42,11 +42,11 @@ export default class NoticeRepository {
         notice.created_at AS createdAt
         FROM notice AS notice
         LEFT JOIN member AS mem ON notice.member_idx = mem.idx
-        WHERE notice.is_deleted = 'f' AND title = $1
+        WHERE notice.is_deleted = 'f' AND title LIKE $1
         ORDER BY 4 DESC
         LIMIT $2 OFFSET $3
         `,
-        [title, display, offset],
+        [titleToSearch, display, offset],
       )
     ).rows
     const totalCountResult = (

--- a/src/notice/service/ListService.ts
+++ b/src/notice/service/ListService.ts
@@ -17,7 +17,7 @@ export default class ListService {
     const noticeList = new NoticeList(
       current,
       display,
-      listData.totalCountResult.totalCount,
+      listData.totalCountResult,
       listData.listResult,
     )
 

--- a/src/notice/service/ListService.ts
+++ b/src/notice/service/ListService.ts
@@ -36,7 +36,7 @@ export default class ListService {
     const noticeList = new NoticeList(
       current,
       display,
-      searchData.totalCountResult.totalCount,
+      searchData.totalCountResult,
       searchData.listResult,
     )
     return ListSearchResponse.of(noticeList)

--- a/src/notice/service/ListService.ts
+++ b/src/notice/service/ListService.ts
@@ -27,8 +27,9 @@ export default class ListService {
   static async searchList(listSearchRequest: ListSearchRequest) {
     const { title, display, current } = listSearchRequest
     const offset = (current - 1) * display
+    const titleToSearch = '%' + title + '%'
     const searchData: any = await NoticeRepository.getSearchListFromDb(
-      title,
+      titleToSearch,
       display,
       offset,
     )


### PR DESCRIPTION
## 📢 설명

공지사항 검색 API기능을 수정했습니다.
검색할 공지사항 제목의 일부만 쿼리로 제공해도 검색하도록 수정하였습니다.


## ✅ 체크 리스트

- [x] '공지'혹은 '수정', 임의 숫자를 쿼리로 넣고 관련된 결과가 나오는 지 확인
![image](https://github.com/user-attachments/assets/5343f4e6-bff8-4ac3-af6d-b899bb149441)
결과가 없을 경우 lastpagenumber가 1이 나오는지 확인 및 결과가 빈 리스트로 주어지는지 확인
![image](https://github.com/user-attachments/assets/07f986ac-fcf5-4174-a120-1a2a4a174791)

- [x] 코드 리뷰
