### PR TITLE
[SUS-75] Oauth 사용자와 일반사용자 이메일 중복 처리

### DIFF
--- a/src/member/repository/MemberLoginRepository.ts
+++ b/src/member/repository/MemberLoginRepository.ts
@@ -15,18 +15,24 @@ export default class MemberLoginRepository {
   /**소셜로그인
    * 계정 존재 여부 확인
    */
-  static async checkMemberDataFromDb(socialId: string, email: string) {
-    return await postgres.query(
-      `SELECT    
-          CASE 
-            WHEN EXISTS (SELECT 1 FROM member WHERE id = $1 AND email = $2) THEN true
-            WHEN EXISTS (SELECT 1 FROM users WHERE email = $2) THEN false
-            ELSE NULL
-          END AS result`,
-      [socialId, email],
-    )
+  static async checkMemberDataFromDb(socialId: string) {
+    return (
+      await postgres.query('SELECT * FROM member WHERE id =$1', [socialId])
+    ).rows[0]
   }
-
+  static async checkGoogleMailAvailable(socialId: string, email: string) {
+    return (
+      await postgres.query(
+        `SELECT 
+    CASE 
+        WHEN EXISTS (SELECT 1 FROM member WHERE id = $1 AND email = $2) THEN true
+        WHEN EXISTS (SELECT 1 FROM member WHERE email = $2) THEN false
+        ELSE NULL
+    END AS result`,
+        [socialId, email],
+      )
+    ).rows[0].result
+  }
   /** 카카오 소셜로그인 회원가입 */
   static async insertKakaoLoginMemberData(socialId: string, nickname: string) {
     let dateTime = new Date()

--- a/src/member/repository/MemberLoginRepository.ts
+++ b/src/member/repository/MemberLoginRepository.ts
@@ -15,10 +15,16 @@ export default class MemberLoginRepository {
   /**소셜로그인
    * 계정 존재 여부 확인
    */
-  static async checkMemberDataFromDb(socialId: string) {
-    return (
-      await postgres.query('SELECT * FROM member WHERE id = $1', [socialId])
-    ).rows[0]
+  static async checkMemberDataFromDb(socialId: string, email: string) {
+    return await postgres.query(
+      `SELECT    
+          CASE 
+            WHEN EXISTS (SELECT 1 FROM member WHERE id = $1 AND email = $2) THEN true
+            WHEN EXISTS (SELECT 1 FROM users WHERE email = $2) THEN false
+            ELSE NULL
+          END AS result`,
+      [socialId, email],
+    )
   }
 
   /** 카카오 소셜로그인 회원가입 */

--- a/src/member/service/LoginService.ts
+++ b/src/member/service/LoginService.ts
@@ -45,10 +45,9 @@ export default class LoginService {
       kakaoToken,
       kakaoOauthUserInfoUrl,
     )
-    const kakaoEmail = `${userData.id}@kakao.com`
+    // const kakaoEmail = `${userData.id}@kakao.com`
     const checkResult: any = await MemberLoginRepository.checkMemberDataFromDb(
       userData.id,
-      kakaoEmail,
     )
 
     if (!checkResult) {
@@ -57,10 +56,7 @@ export default class LoginService {
         userData.properties.nickname,
       )
       const checkResult: any =
-        await MemberLoginRepository.checkMemberDataFromDb(
-          userData.id,
-          kakaoEmail,
-        )
+        await MemberLoginRepository.checkMemberDataFromDb(userData.id)
       const token = Token.generateLoginToken(
         checkResult.idx,
         checkResult.email,
@@ -85,33 +81,29 @@ export default class LoginService {
     res: Response,
   ): Promise<string> {
     const googleLoginToken = await LoginAdapter.getGoogleToken(code)
-    console.log(1)
     const userData = await LoginAdapter.getUserDataByToken(
       googleLoginToken,
       googleOauthUserInfoUrl,
     )
-    console.log(2)
-    console.log(userData)
     const checkResult: any = await MemberLoginRepository.checkMemberDataFromDb(
       userData.id,
-      userData.email,
     )
-    console.log(3)
-    console.log(checkResult)
-    if (checkResult == false) {
+    const checkEmail: any =
+      await MemberLoginRepository.checkGoogleMailAvailable(
+        userData.id,
+        userData.email,
+      )
+    if (checkEmail == false) {
       throw ErrorRegistry.DUPLICATED_EMAIL
     }
     if (!checkResult) {
-      await await MemberLoginRepository.insertGoogleLoginMemberData(
+      await MemberLoginRepository.insertGoogleLoginMemberData(
         userData.id,
         userData.name,
         userData.email,
       )
       const checkResult: any =
-        await MemberLoginRepository.checkMemberDataFromDb(
-          userData.id,
-          userData.email,
-        )
+        await MemberLoginRepository.checkMemberDataFromDb(userData.id)
       const token = Token.generateLoginToken(
         checkResult.idx,
         checkResult.email,

--- a/src/member/service/LoginService.ts
+++ b/src/member/service/LoginService.ts
@@ -45,8 +45,10 @@ export default class LoginService {
       kakaoToken,
       kakaoOauthUserInfoUrl,
     )
+    const kakaoEmail = `${userData.id}@kakao.com`
     const checkResult: any = await MemberLoginRepository.checkMemberDataFromDb(
       userData.id,
+      kakaoEmail,
     )
 
     if (!checkResult) {
@@ -55,7 +57,10 @@ export default class LoginService {
         userData.properties.nickname,
       )
       const checkResult: any =
-        await MemberLoginRepository.checkMemberDataFromDb(userData.id)
+        await MemberLoginRepository.checkMemberDataFromDb(
+          userData.id,
+          kakaoEmail,
+        )
       const token = Token.generateLoginToken(
         checkResult.idx,
         checkResult.email,
@@ -80,22 +85,33 @@ export default class LoginService {
     res: Response,
   ): Promise<string> {
     const googleLoginToken = await LoginAdapter.getGoogleToken(code)
+    console.log(1)
     const userData = await LoginAdapter.getUserDataByToken(
       googleLoginToken,
       googleOauthUserInfoUrl,
     )
+    console.log(2)
+    console.log(userData)
     const checkResult: any = await MemberLoginRepository.checkMemberDataFromDb(
       userData.id,
+      userData.email,
     )
-
+    console.log(3)
+    console.log(checkResult)
+    if (checkResult == false) {
+      throw ErrorRegistry.DUPLICATED_EMAIL
+    }
     if (!checkResult) {
-      await MemberLoginRepository.insertGoogleLoginMemberData(
+      await await MemberLoginRepository.insertGoogleLoginMemberData(
         userData.id,
         userData.name,
         userData.email,
       )
       const checkResult: any =
-        await MemberLoginRepository.checkMemberDataFromDb(userData.id)
+        await MemberLoginRepository.checkMemberDataFromDb(
+          userData.id,
+          userData.email,
+        )
       const token = Token.generateLoginToken(
         checkResult.idx,
         checkResult.email,


### PR DESCRIPTION
## 📢 설명

구글 이메일을 통해 일반 회원가입을 한 사용자가 Oauth를 통해 해당 구글 이메일로 로그인 시도 시 
중복 가입을 차단하였습니다.

## ✅ 체크 리스트

- [x] 일반회원가입을 구글 이메일로 시도
- [x] 해당 구글 이메일로 Oauth 로그인을 시도 (localhost:3000/member/login/google)
![image](https://github.com/user-attachments/assets/06128f69-04b2-444c-8328-e00ee36ec322)
해당 오류가 발생하는지 확인
