### PR TITLE
[SUS-78] 정규표현식 검증 수정

### DIFF
--- a/src/member/entity/dao/frontend/request/NicknameChangeRequest.ts
+++ b/src/member/entity/dao/frontend/request/NicknameChangeRequest.ts
@@ -9,7 +9,7 @@ export default class NicknameChangeRequest {
   public nickname: string
 
   constructor(params: NicknameChangeRequestParams) {
-    if (!new RegExp(Regex.NICKNAME).test(params.nickname)) {
+    if (!Regex.NICKNAME.test(params.nickname)) {
       throw ErrorRegistry.INVALID_INPUT_FORMAT
     }
     this.nickname = params.nickname

--- a/src/member/entity/dao/frontend/request/PasswordChangeRequest.ts
+++ b/src/member/entity/dao/frontend/request/PasswordChangeRequest.ts
@@ -12,7 +12,7 @@ export default class PasswordChangeRequest {
   public token: string
 
   constructor(params: PasswordChangeRequestParams) {
-    if (!new RegExp(Regex.PASSWORD).test(params.password)) {
+    if (!Regex.PASSWORD.test(params.password)) {
       throw ErrorRegistry.INVALID_INPUT_FORMAT
     }
     if (params.password != params.passwordCheck) {

--- a/src/member/entity/dao/frontend/request/SendFindPasswordEmailRequest.ts
+++ b/src/member/entity/dao/frontend/request/SendFindPasswordEmailRequest.ts
@@ -11,10 +11,7 @@ export default class SendFindPasswordEmailRequest {
   public email: string
 
   constructor(params: SendFindPasswordEmailRequestParams) {
-    if (
-      !new RegExp(Regex.ID).test(params.id) ||
-      !new RegExp(Regex.EMAIL).test(params.email)
-    ) {
+    if (!Regex.ID.test(params.id) || !Regex.EMAIL.test(params.email)) {
       throw ErrorRegistry.INVALID_INPUT_FORMAT
     }
     this.id = params.id

--- a/src/member/entity/dao/frontend/request/SendVerifyEmailRequest.ts
+++ b/src/member/entity/dao/frontend/request/SendVerifyEmailRequest.ts
@@ -9,7 +9,7 @@ export default class SendVerifyEmailRequest {
   public email: string
 
   constructor(params: SendVerifyEmailRequestParams) {
-    if (!new RegExp(Regex.EMAIL).test(params.email)) {
+    if (!Regex.EMAIL.test(params.email)) {
       throw ErrorRegistry.INVALID_INPUT_FORMAT
     }
     this.email = params.email

--- a/src/member/entity/dao/frontend/request/SignupRequest.ts
+++ b/src/member/entity/dao/frontend/request/SignupRequest.ts
@@ -16,10 +16,10 @@ export default class SignupRequest {
 
   constructor(params: SignupRequestParams) {
     if (
-      !new RegExp(Regex.ID).test(params.id) ||
-      !new RegExp(Regex.PASSWORD).test(params.password) ||
-      !new RegExp(Regex.PASSWORD).test(params.passwordCheck) ||
-      !new RegExp(Regex.EMAIL).test(params.email)
+      !Regex.ID.test(params.id) ||
+      !Regex.PASSWORD.test(params.password) ||
+      !Regex.PASSWORD.test(params.passwordCheck) ||
+      !Regex.EMAIL.test(params.email)
     ) {
       throw ErrorRegistry.INVALID_INPUT_FORMAT
     }

--- a/src/mock/entity/dao/frontend/request/body/MockEditRequest.ts
+++ b/src/mock/entity/dao/frontend/request/body/MockEditRequest.ts
@@ -14,7 +14,7 @@ export default class MockEditRequest {
 
   constructor(params: MockEditRequestParams) {
     if (
-      !new RegExp(Regex.TITLE).test(params.title) ||
+      !Regex.TITLE.test(params.title) ||
       (params.description && params.description.length > 1000)
     ) {
       throw ErrorRegistry.INVALID_INPUT_FORMAT

--- a/src/mock/entity/dao/frontend/request/body/QuizRequest.ts
+++ b/src/mock/entity/dao/frontend/request/body/QuizRequest.ts
@@ -10,7 +10,7 @@ export default class QuizRequest {
   public idx: UUID
 
   constructor(params: QuizRequestParams) {
-    if (!new RegExp(Regex.UUID).test(params.idx)) {
+    if (!Regex.UUID.test(params.idx)) {
       throw ErrorRegistry.INVALID_INPUT_FORMAT
     }
     this.idx = params.idx

--- a/src/mock/entity/dao/frontend/request/body/WriteRequest.ts
+++ b/src/mock/entity/dao/frontend/request/body/WriteRequest.ts
@@ -18,8 +18,8 @@ export default class WriteRequest {
 
   constructor(params: WriteRequestParams) {
     if (
-      !new RegExp(Regex.SUBJECT).test(params.subject) ||
-      !new RegExp(Regex.TITLE).test(params.title) ||
+      !Regex.SUBJECT.test(params.subject) ||
+      !Regex.TITLE.test(params.title) ||
       (params.description && params.description.length > 1000) ||
       params.quizCount > 10 ||
       params.quizCount < 0

--- a/src/mock/entity/dao/frontend/request/path/MockIdxPath.ts
+++ b/src/mock/entity/dao/frontend/request/path/MockIdxPath.ts
@@ -10,7 +10,7 @@ export default class MockIdxPath {
   public idx: UUID
 
   constructor(params: MockIdxPathParams) {
-    if (!new RegExp(Regex.UUID).test(params.idx)) {
+    if (!Regex.UUID.test(params.idx)) {
       throw ErrorRegistry.INVALID_INPUT_FORMAT
     }
     this.idx = params.idx

--- a/src/mock/entity/dao/frontend/request/path/QuizIdxPath.ts
+++ b/src/mock/entity/dao/frontend/request/path/QuizIdxPath.ts
@@ -10,7 +10,7 @@ export default class QuizIdxPath {
   public idx: UUID
 
   constructor(params: QuizIdxPathParams) {
-    if (!new RegExp(Regex.UUID).test(params.idx)) {
+    if (Regex.UUID.test(params.idx)) {
       throw ErrorRegistry.INVALID_INPUT_FORMAT
     }
     this.idx = params.idx

--- a/src/notice/entity/dao/frontend/request/NoticeEditBodyRequest.ts
+++ b/src/notice/entity/dao/frontend/request/NoticeEditBodyRequest.ts
@@ -13,7 +13,7 @@ export default class NoticeEditBodyRequest {
   public uploadUrls: string[]
   constructor(params: NoticeEditBodyRequestParams) {
     if (
-      !new RegExp(Regex.TITLE).test(params.title) ||
+      !Regex.TITLE.test(params.title) ||
       (params.content && params.content.length > 1000)
     ) {
       throw ErrorRegistry.INVALID_INPUT_FORMAT

--- a/src/notice/entity/dao/frontend/request/NoticePathRequest.ts
+++ b/src/notice/entity/dao/frontend/request/NoticePathRequest.ts
@@ -9,7 +9,7 @@ interface NoticePathRequestParams {
 export default class NoticePathRequest {
   public idx: UUID
   constructor(params: NoticePathRequestParams) {
-    if (!new RegExp(Regex.UUID).test(params.idx)) {
+    if (!Regex.UUID.test(params.idx)) {
       throw ErrorRegistry.INVALID_INPUT_FORMAT
     }
     this.idx = params.idx

--- a/src/notice/entity/dao/frontend/request/WriteRequest.ts
+++ b/src/notice/entity/dao/frontend/request/WriteRequest.ts
@@ -13,7 +13,7 @@ export default class WriteRequest {
   public uploadUrls: string[]
   constructor(params: WriteRequestParams) {
     if (
-      !new RegExp(Regex.TITLE).test(params.title) ||
+      !Regex.TITLE.test(params.title) ||
       (params.content && params.content.length > 10000)
     ) {
       throw ErrorRegistry.INVALID_INPUT_FORMAT

--- a/src/rank/entity/dao/request/FilteredRankListRequest.ts
+++ b/src/rank/entity/dao/request/FilteredRankListRequest.ts
@@ -12,7 +12,7 @@ export default class FilteredRankListRequest {
   public current: number
   public nickname: string
   constructor(params: FilteredRankListRequestParams) {
-    if (params.tier && !new RegExp(Regex.TIER).test(params.tier)) {
+    if (params.tier && !Regex.TIER.test(params.tier)) {
       throw ErrorRegistry.INVALID_INPUT_FORMAT
     }
     if (!params.tier) {

--- a/src/rank/entity/dao/request/RankListRequest.ts
+++ b/src/rank/entity/dao/request/RankListRequest.ts
@@ -17,7 +17,7 @@ export default class RankListRequest {
     }
     this.current = Number(params.current)
 
-    if (params.tier && !new RegExp(Regex.TIER).test(params.tier)) {
+    if (params.tier && !Regex.TIER.test(params.tier)) {
       throw ErrorRegistry.INVALID_INPUT_FORMAT
     }
     this.tier = params.tier


### PR DESCRIPTION
## 📢 설명

입력 값을 정규표현식과 비교하는 코드를 수정하였습니다.
기존의 객체 선언부분을 삭제하고 직접 비교하도록 수정하였습니다.

## ✅ 체크 리스트

- [x] Request에서 입력 값이 제대로 검증되는지 확인
값이 없거나, regex의 정규표현식에 어긋나는 값을 넣고 
오류가 발생하는 지 확인
- [x] 코드 리뷰
